### PR TITLE
Describe options

### DIFF
--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -64,6 +64,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    if: (github.event_name != 'push' || github.ref == 'refs/heads/main') && github.event_name != 'pull_request'
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,3 +2,4 @@
 
 [Introduction](README.md)
 - [Deploy a DNSvizor unikernel](./dnsvizor_unikernel.md)
+  - [DNSvizor options](./dnsvizor_options.md)

--- a/src/dnsvizor_options.md
+++ b/src/dnsvizor_options.md
@@ -43,3 +43,4 @@ If you use Dnsmasq and are missing any options in DNSvizor please [reach out to 
 - `--dhcp-range=<start>[,<end>|<mode>[,<netmask>[,<broadcast>]]][,<lease-time>]` enable the DHCP server.
 
 [mirage]: https://mirageos.org/
+[contact]: https://robur.coop/Contact

--- a/src/dnsvizor_options.md
+++ b/src/dnsvizor_options.md
@@ -1,0 +1,45 @@
+# DNSvizor options
+
+The options we pass to DNSvizor can be put into three overall categories:
+- [Mirage options](#mirage-options),
+- [DNSvizor options](#dnsvizor-options),
+- [Dnsmasq-compatible options](#dnsmasq-compatible-options).
+
+All options with a description can be listed by running DNSvizor with `--help` as argument.
+The options are then printed to stdout.
+Note that you still need to pass a network device to `solo5-hvt`.
+
+## Mirage options
+These options relate to [MirageOS][mirage], the library operating system used to build DNSvizor.
+Important options are `--help`, network options and log options:
+
+### Mirage network options
+Notable options are:
+- `--ipv4=<PREFIX>`
+- `--ipv4-gateway=<IP>`
+- `--ipv4-only={true|false}`
+There are as well IPv6 options.
+See the `--help` output for more information.
+
+## DNSvizor options
+DNSvizor strives for a degree of compatibility with Dnsmasq.
+Thus most options are Dnsmasq-compatible.
+See the [section further down](#dnsmasq-compatible-options) for information on those.
+The non-dnsmasq-compatible options are:
+
+- `--name=<name>` which would be equivalent of the hostname of a Dnsmasq setup - that is, the hostname you would find in /etc/hostname on a \*NIX system.
+- `--https-port=<port>` the port for the DNSvizor https web interface.
+- `--ca-seed=<base64-seed>` is the seed to generate the self-signed certificate from for the DNSvizor web interface.
+- `--dns-block=<hostname>` adds `hostname` to the DNS block list.
+- `--dns-blocklist-url=<url>` adds `url` to the list of DNS block list sources to fetch.
+- `--dns-cache=<size>` the size of the DNS cache.
+<!-- TODO: --dns-upstream -->
+
+## Dnsmasq-comaptible options
+The following options are compatible with Dnsmasq.
+If you use Dnsmasq and are missing any options in DNSvizor please [reach out to us][contact].
+
+- `--dnssec` validate DNS replies and cache DNSSEC data.
+- `--dhcp-range=<start>[,<end>|<mode>[,<netmask>[,<broadcast>]]][,<lease-time>]` enable the DHCP server.
+
+[mirage]: https://mirageos.org/

--- a/src/dnsvizor_unikernel.md
+++ b/src/dnsvizor_unikernel.md
@@ -4,7 +4,9 @@ configuration is close to dnsmasq.
 ## Installation
 
 You can download the unikernel binary from [our reproducible build infrastructure](https://builds.robur.coop/job/dnsvizor/build/latest). Download the `bin/dnsvizor.hvt` artifact.
-If you did that, skip to ["DNSvizor Configuration"](#dnsvizor-configuration).
+You need as well `solo5-hvt` which [our reproducible build infrastructure](https://builds.robur.coop/job/solo5) builds for select platforms.
+If we don't build for your platform you need to [build it yourself](#building-solo5-from-source-alternative).
+If you did all of that, skip to ["DNSvizor Configuration"](#dnsvizor-configuration).
 
 ## Building from source (alternative)
 
@@ -32,6 +34,10 @@ $ make
 ```
 
 The result is a binary, `dist/dnsvizor.hvt`, which we will use later.
+
+## Building solo5 from source (alternative)
+
+See the instructions in [doc/building.md](https://github.com/Solo5/solo5/blob/master/docs/building.md) in the Solo5 source tree.
 
 ## DNSvizor Configuration
 

--- a/src/dnsvizor_unikernel.md
+++ b/src/dnsvizor_unikernel.md
@@ -95,7 +95,7 @@ $ solo5-hvt --mem=96--net:service=tap0 --net-mac:service=00:80:41:ad:30:5e -- \
 The solo5-hvt arguments follow the overall pattern `$ solo5-hvt <solo5-options> -- <kernel> <dnsvizor-arguments>`.
 The relevant solo5-options are:
 - `--mem 96` which allocates 96 MB of memory to dnsvizor. It can be omitted with a default allocation of 512 MB.
-- `--net:service=tap0` tells `solo5-hvt` to use the [tap interface][tap-interface] `tap0` for the unikernel network `service`. This is required for DNSvizor as it expects exactly one network named `service`.
+- `--net:service=tap0` tells `solo5-hvt` to use the TAP interface `tap0` for the unikernel network `service`. This is required for DNSvizor as it expects exactly one network named `service`.
 - `--net-mac:service=00:80:41:ad:30:5e` tells `solo5-hvt` to assign the MAC address `00:80:41:ad:30:5e` to the unikernel network `service`. This is optional; if omitted a random MAC address is generated. Note that this may cause issues with ARP tables in the network.
 
 ### DNSvizor options

--- a/src/dnsvizor_unikernel.md
+++ b/src/dnsvizor_unikernel.md
@@ -79,7 +79,20 @@ To launch the unikernel, you need a solo5 tender (that the Building section
 already installed).
 
 ```sh
-$ solo5-hvt --net:service=tap0 -- \
+$ solo5-hvt --mem=96--net:service=tap0 --net-mac:service=00:80:41:ad:30:5e -- \
     dnsvizor.hvt --ipv4=10.0.0.2/24 --ipv4-gateway=10.0.0.1 --name=dnsvizor \
     --ca-seed=my-random-seed --password='my password'
 ```
+
+### Solo5-hvt options
+
+The solo5-hvt arguments follow the overall pattern `$ solo5-hvt <solo5-options> -- <kernel> <dnsvizor-arguments>`.
+The relevant solo5-options are:
+- `--mem 96` which allocates 96 MB of memory to dnsvizor. It can be omitted with a default allocation of 512 MB.
+- `--net:service=tap0` tells `solo5-hvt` to use the [tap interface][tap-interface] `tap0` for the unikernel network `service`. This is required for DNSvizor as it expects exactly one network named `service`.
+- `--net-mac:service=00:80:41:ad:30:5e` tells `solo5-hvt` to assign the MAC address `00:80:41:ad:30:5e` to the unikernel network `service`. This is optional; if omitted a random MAC address is generated. Note that this may cause issues with ARP tables in the network.
+
+### DNSvizor options
+
+In the above example DNSvizor gets the arguments `--ipv4`, `--ipv4-gateway`, `--name`, `--ca-seed` and `--password`.
+For more information about DNSvizor arguments see [DNSvizor options](./dnsvizor_options.md).


### PR DESCRIPTION
This adds a sub chapter on DNSvizor options, and expands the solo5-hvt invocation and explains roughly what the options do.